### PR TITLE
Fix/bash env test

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "nexus-push"
-version: "0.0.1"
+version: "1.0.0"
 usage: "Push chart or packaged chart to a specified repo"
 description: |-
   Pushes a chart directory or packaged chart tgz to a specified repo,

--- a/push.sh
+++ b/push.sh
@@ -70,7 +70,7 @@ declare REPO=$1
 declare REPO_URL="$(helm repo list | grep "^$REPO" | awk '{print $2}')/"
 declare REPO_AUTH_FILE="$(helm home)/repository/auth.$REPO"
 
-if [[ -z "$REPO_URL" ]]; then
+if [[ -z "${REPO_URL:-}" ]]; then
     echo "Invalid repo specified!  Must specify one of these repos..."
     helm repo list
     echo "---"
@@ -84,10 +84,10 @@ declare CHART
 
 case "$2" in
     login)
-        if [[ -z "$USERNAME" ]]; then
+        if [[ -z "${USERNAME:-}" ]]; then
             read -p "Username: " USERNAME
         fi
-        if [[ -z "$PASSWORD" ]]; then
+        if [[ -z "${PASSWORD:-}" ]]; then
             read -s -p "Password: " PASSWORD
             echo
         fi
@@ -100,15 +100,15 @@ case "$2" in
         CMD=push
         CHART=$2
 
-        if [[ -z "$USERNAME" ]] || [[ -z "$PASSWORD" ]]; then
-            if [[ -f "$REPO_AUTH_FILE" ]]; then
+        if [[ -z "${USERNAME:-}" ]] || [[ -z "${PASSWORD:-}" ]]; then
+            if [[ -f "${REPO_AUTH_FILE:-}" ]]; then
                 echo "Using cached login creds..."
                 AUTH="$(cat $REPO_AUTH_FILE)"
             else
-                if [[ -z "$USERNAME" ]]; then
+                if [[ -z "${USERNAME:-}" ]]; then
                     read -p "Username: " USERNAME
                 fi
-                if [[ -z "$PASSWORD" ]]; then
+                if [[ -z "${PASSWORD:-}" ]]; then
                     read -s -p "Password: " PASSWORD
                     echo
                 fi
@@ -116,7 +116,7 @@ case "$2" in
             fi
         fi
 
-        if [[ -d "$CHART" ]]; then
+        if [[ -d "${CHART:-}" ]]; then
             CHART_PACKAGE="$(helm package "$CHART" | cut -d":" -f2 | tr -d '[:space:]')"
         else
             CHART_PACKAGE="$CHART"

--- a/push.sh
+++ b/push.sh
@@ -112,9 +112,9 @@ case "$2" in
                     read -s -p "Password: " PASSWORD
                     echo
                 fi
-                AUTH="$USERNAME:$PASSWORD"
             fi
         fi
+        AUTH="$USERNAME:$PASSWORD"
 
         if [[ -d "${CHART:-}" ]]; then
             CHART_PACKAGE="$(helm package "$CHART" | cut -d":" -f2 | tr -d '[:space:]')"

--- a/push.sh
+++ b/push.sh
@@ -112,9 +112,11 @@ case "$2" in
                     read -s -p "Password: " PASSWORD
                     echo
                 fi
+                AUTH="$USERNAME:$PASSWORD"
             fi
+        else
+            AUTH="$USERNAME:$PASSWORD"
         fi
-        AUTH="$USERNAME:$PASSWORD"
 
         if [[ -d "${CHART:-}" ]]; then
             CHART_PACKAGE="$(helm package "$CHART" | cut -d":" -f2 | tr -d '[:space:]')"


### PR DESCRIPTION
Using the plugin in some docker images produce an 'unbound variable' error by pushing charts to the nexus repository.

You can reproduce this issue by using the 'devth/helm' docker image.

This pull request makes the following changes:
* Adapt the bash 'if' checks on env vars with the :- notation to set a default value empty string
  (http://wiki.bash-hackers.org/syntax/pe#use_a_default_value)
* Move the setting of the AUTH env var to include the case were passing user/pw to the push command
* Add a 1.0.0 version as defined in semantic versioning
