### PR TITLE
remove set -u and reserved variable USERNAME

### DIFF
--- a/push.sh
+++ b/push.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ueo pipefail
+set -eo pipefail
 
 usage() {
 cat << EOF
@@ -20,7 +20,7 @@ Flags:
 EOF
 }
 
-declare USERNAME
+declare REPO_USERNAME
 declare PASSWORD
 
 declare -a POSITIONAL_ARGS=()
@@ -39,7 +39,7 @@ do
                 exit 1
             fi
             shift
-            USERNAME=$1
+            REPO_USERNAME=$1
             ;;
         -p|--password)
             if [[ -n "${2:-}" ]]; then
@@ -84,14 +84,14 @@ declare CHART
 
 case "$2" in
     login)
-        if [[ -z "$USERNAME" ]]; then
-            read -p "Username: " USERNAME
+        if [[ -z "$REPO_USERNAME" ]]; then
+            read -p "Username: " REPO_USERNAME
         fi
         if [[ -z "$PASSWORD" ]]; then
             read -s -p "Password: " PASSWORD
             echo
         fi
-        echo "$USERNAME:$PASSWORD" > "$REPO_AUTH_FILE"
+        echo "$REPO_USERNAME:$PASSWORD" > "$REPO_AUTH_FILE"
         ;;
     logout)
         rm -f "$REPO_AUTH_FILE"
@@ -100,19 +100,19 @@ case "$2" in
         CMD=push
         CHART=$2
 
-        if [[ -z "$USERNAME" ]] || [[ -z "$PASSWORD" ]]; then
+        if [[ -z "$REPO_USERNAME" ]] || [[ -z "$PASSWORD" ]]; then
             if [[ -f "$REPO_AUTH_FILE" ]]; then
                 echo "Using cached login creds..."
                 AUTH="$(cat $REPO_AUTH_FILE)"
             else
-                if [[ -z "$USERNAME" ]]; then
-                    read -p "Username: " USERNAME
+                if [[ -z "$REPO_USERNAME" ]]; then
+                    read -p "Username: " REPO_USERNAME
                 fi
                 if [[ -z "$PASSWORD" ]]; then
                     read -s -p "Password: " PASSWORD
                     echo
                 fi
-                AUTH="$USERNAME:$PASSWORD"
+                AUTH="$REPO_USERNAME:$PASSWORD"
             fi
         fi
 


### PR DESCRIPTION
fix unbound variable error, the script call USERNAME and PASSWORD before setting it. 
USERNAME is reserved in Ubuntu 18.04 

This pull request makes the following changes:
* remove set -u  due to error `.helm/plugins/helm-nexus-push.git/push.sh: line 104: PASSWORD: unbound variable`
* change reserved variable USERNAME (on ubuntu linux USERNAME is my os username)


(If there are changes to user behavior in general, please make sure to
update the docs, as well)

It relates to the following issue #s:
* Fixes #X
