### PR TITLE
Fix in case username and password are both specified in command line

### DIFF
--- a/push.sh
+++ b/push.sh
@@ -114,6 +114,8 @@ case "$2" in
                 fi
                 AUTH="$USERNAME:$PASSWORD"
             fi
+	else
+		AUTH="$USERNAME:$PASSWORD"
         fi
 
         if [[ -d "$CHART" ]]; then


### PR DESCRIPTION
If you issue the following command:
`helm nexus-push wph wph-component -u deployment -p KMdep31-xy wph-component`
the push.sh script will issue the error:

> AUTH: unbound variable

This pull request fix a bug that does not declare AUTH variable (username:password) when both parameters are specified in command line.