### PR TITLE
fix a case on some shells that the declare results on a undeclared variable

### DIFF
--- a/push.sh
+++ b/push.sh
@@ -20,8 +20,8 @@ Flags:
 EOF
 }
 
-declare USERNAME
-declare PASSWORD
+declare USERNAME=
+declare PASSWORD=
 
 declare -a POSITIONAL_ARGS=()
 while [[ $# -gt 0 ]]


### PR DESCRIPTION
leading to an assertion error

Just added equal signs to the declare, so it behave correctly, and the if -z assertion works as intended. However, i only tested on ubuntu 18 machine, wich is the OS that was trying to use this script.