### PR TITLE
Avoid Grep matching repo names with the same prefix

### DIFF
--- a/push.sh
+++ b/push.sh
@@ -69,7 +69,7 @@ indent() { sed 's/^/  /'; }
 declare HELM3_VERSION="$(helm version --client --short | grep "v3\.")"
 
 declare REPO=$1
-declare REPO_URL="$(helm repo list | grep "^$REPO" | awk '{print $2}')/"
+declare REPO_URL="$(helm repo list | grep "^$REPO[[:space:]]" | awk '{print $2}')/"
 
 if [[ -n $HELM3_VERSION ]]; then
 declare REPO_AUTH_FILE="$HOME/.config/helm/auth.$REPO"


### PR DESCRIPTION
Some similar repo names will be repeated by grep

This pull request makes the following changes:
* When grep query, add spaces to truncate the repo name to make the query more accurate 

It relates to the following issue #s:
* Fixes #15 X](https://github.com/sonatype-nexus-community/helm-nexus-push/issues/11)
